### PR TITLE
Add gitignore to exclude binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+gallery/
+*.jar
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.bmp
+*.tiff
+*.ttf
+*.otf


### PR DESCRIPTION
## Summary
- exclude the cloned `gallery` directory and common binary file types

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68475a91c3bc8321ad405b52faa68337